### PR TITLE
feat: Add pagination to tournament routes

### DIFF
--- a/tournament_app_backend/app/routers/tournaments.py
+++ b/tournament_app_backend/app/routers/tournaments.py
@@ -11,9 +11,11 @@ from exceptions.tournamentExceptions import (
     TournamentForbiddenException,
 )
 
-
 from fastapi.routing import APIRouter
 from fastapi import status, Depends, Path
+
+from fastapi_pagination import Page
+from fastapi_pagination.customization import CustomizedPage, UseParamsFields
 
 from models.user import UserModel
 from models.tournament import (
@@ -56,9 +58,15 @@ router = APIRouter(
 """
 CurrentUser = Annotated[UserModel, Depends(get_current_user)]
 
+# Changing pagination params default values
+CustomPage = CustomizedPage[
+    Page,
+    UseParamsFields(size=10),
+]
+
 
 @router.get("/")
-async def get_tournaments() -> list[TournamentResponseModel]:
+async def get_tournaments() -> CustomPage[TournamentResponseModel]:
     logger.info("Retrieving all tournaments")
     tournaments = await get_all_tournaments()
     return tournaments

--- a/tournament_app_backend/app/services/tournamentService.py
+++ b/tournament_app_backend/app/services/tournamentService.py
@@ -7,8 +7,9 @@ from exceptions.tournamentExceptions import (
     TournamentForbiddenException,
 )
 
+from fastapi_pagination.ext.beanie import paginate
+
 from models.documentModels.tournaments import TournamentDBModel
-from models.documentModels.events import EventDBModel
 from models.tournament import TournamentModel, TournamentResponseModel
 from models.user import UserModel
 
@@ -22,13 +23,16 @@ logger = logging.getLogger(__name__)
 
 
 async def get_all_tournaments():
-    tournaments = TournamentDBModel.find_all()
-    tournament_list = await tournaments.to_list()
-    logger.info(f"Retrieved {len(tournament_list)} tournaments")
-    tournaments = [
-        TournamentResponseModel(tournament_id=tournament.id, **tournament.model_dump())
-        for tournament in tournament_list
-    ]
+    tournaments = await paginate(
+        query=TournamentDBModel.find_all(),
+        transformer=lambda tournament_list: [
+            TournamentResponseModel(
+                tournament_id=tournament.id, **tournament.model_dump()
+            )
+            for tournament in tournament_list
+        ],
+    )
+    logger.info(f"Retrieved {len(tournaments.items)} tournaments")
     return tournaments
 
 


### PR DESCRIPTION
### **Changes**

Added pagination to the  `GET /tournaments` route and `get_all_tournaments` service.

![image](https://github.com/user-attachments/assets/ebd9841e-6b5f-48ed-a850-11032a490337)
