### PR TITLE
feat: Create tournament page

### DIFF
--- a/tournament_app/app/layout.tsx
+++ b/tournament_app/app/layout.tsx
@@ -27,7 +27,6 @@ export default function RootLayout({
             <Layout_check />
           </div>
           <div className="w-full">
-            <SidebarTrigger />
             <Providers>{children}</Providers>
           </div>
         </SidebarProvider>

--- a/tournament_app/app/layout.tsx
+++ b/tournament_app/app/layout.tsx
@@ -27,6 +27,7 @@ export default function RootLayout({
             <Layout_check />
           </div>
           <div className="w-full">
+            <SidebarTrigger />
             <Providers>{children}</Providers>
           </div>
         </SidebarProvider>

--- a/tournament_app/app/login/GoogleSignInButton.tsx
+++ b/tournament_app/app/login/GoogleSignInButton.tsx
@@ -24,6 +24,7 @@ function GoogleSignInButton() {
       const res = await signInWithGoogle();
       if (res) {
         const token = await res.user.getIdToken();
+        console.log(token);
         await createSession(token);
         router.push("/");
       }

--- a/tournament_app/app/login/page.tsx
+++ b/tournament_app/app/login/page.tsx
@@ -68,7 +68,9 @@ function page() {
               onSubmit={form.handleSubmit(handleSubmit)}
               className="max-w-xs w-full flex flex-col gap-4 "
             >
-              <h1 className="text-center text-3xl font-semibold mb-8">Login</h1>
+              <h1 className="scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl text-center">
+                Login
+              </h1>
               <FormField
                 control={form.control}
                 name="emailAddress"

--- a/tournament_app/app/tournaments/TournamentList.tsx
+++ b/tournament_app/app/tournaments/TournamentList.tsx
@@ -3,16 +3,25 @@
 import { Tournament } from "@/components/lib/types";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import React from "react";
+import { useRouter } from "next/navigation";
 
 interface TournamentListProps {
   tournaments: Tournament[];
 }
 
 function TournamentList({ tournaments }: TournamentListProps) {
+  const router = useRouter();
+
   return (
     <div className="space-y-4">
       {tournaments.map((tournament) => (
-        <Card key={tournament.tournament_id}>
+        <Card
+          key={tournament.tournament_id}
+          className="shadow-sm hover:shadow-md transition-shadow duration-300 ease-in-out cursor-pointer"
+          onClick={() =>
+            router.push(`/tournaments/${tournament.tournament_id}`)
+          }
+        >
           <CardHeader>
             <CardTitle>{tournament.tournament_name}</CardTitle>
           </CardHeader>

--- a/tournament_app/app/tournaments/TournamentList.tsx
+++ b/tournament_app/app/tournaments/TournamentList.tsx
@@ -25,9 +25,7 @@ function TournamentList({ tournaments }: TournamentListProps) {
           <CardHeader>
             <CardTitle>{tournament.tournament_name}</CardTitle>
           </CardHeader>
-          <CardContent>
-            <p>{tournament.description}</p>
-          </CardContent>
+          <CardContent>{tournament.description}</CardContent>
         </Card>
       ))}
     </div>

--- a/tournament_app/app/tournaments/Tournaments.tsx
+++ b/tournament_app/app/tournaments/Tournaments.tsx
@@ -21,7 +21,7 @@ function Tournaments({ searchParams }: TournamentsProps) {
   if (error) return <div>Error: {error.message}</div>;
 
   return (
-    <div>
+    <div className="flex flex-col gap-4">
       <TournamentList tournaments={data?.items || []} />
       <PaginationWithLinks
         page={currentPage}

--- a/tournament_app/app/tournaments/[tournament]/NavBar.tsx
+++ b/tournament_app/app/tournaments/[tournament]/NavBar.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import Link from "next/link";
+
+import {
+  NavigationMenu,
+  NavigationMenuItem,
+  NavigationMenuLink,
+  NavigationMenuList,
+  navigationMenuTriggerStyle,
+} from "@/components/ui/navigation-menu";
+
+function NavBar(props: { tournamentId: string }) {
+  const tournamentId = props.tournamentId;
+  return (
+    <NavigationMenu>
+      <NavigationMenuList className="underline-offset-8 gap-4">
+        <NavigationMenuItem>
+          <Link
+            href={`/tournaments/${tournamentId}/rules`}
+            legacyBehavior
+            passHref
+          >
+            <NavigationMenuLink className={navigationMenuTriggerStyle()}>
+              <u>Rules</u>
+            </NavigationMenuLink>
+          </Link>
+        </NavigationMenuItem>
+        <NavigationMenuItem>
+          <Link
+            href={`/tournaments/${tournamentId}/people`}
+            legacyBehavior
+            passHref
+          >
+            <NavigationMenuLink className={navigationMenuTriggerStyle()}>
+              <u>People</u>
+            </NavigationMenuLink>
+          </Link>
+        </NavigationMenuItem>
+        <NavigationMenuItem>
+          <Link
+            href={`/tournaments/${tournamentId}/drafts`}
+            legacyBehavior
+            passHref
+          >
+            <NavigationMenuLink className={navigationMenuTriggerStyle()}>
+              <u>Drafts</u>
+            </NavigationMenuLink>
+          </Link>
+        </NavigationMenuItem>
+        <NavigationMenuItem>
+          <Link
+            href={`/tournaments/${tournamentId}/schedule`}
+            legacyBehavior
+            passHref
+          >
+            <NavigationMenuLink className={navigationMenuTriggerStyle() + ""}>
+              <u>Schedule</u>
+            </NavigationMenuLink>
+          </Link>
+        </NavigationMenuItem>
+      </NavigationMenuList>
+    </NavigationMenu>
+  );
+}
+
+export default NavBar;

--- a/tournament_app/app/tournaments/[tournament]/TournamentHeader.tsx
+++ b/tournament_app/app/tournaments/[tournament]/TournamentHeader.tsx
@@ -1,8 +1,32 @@
 import { Tournament } from "@/components/lib/types";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { CircleUserRound, Pencil } from "lucide-react";
 import React from "react";
 
 function TournamentHeader({ tournament }: { tournament: Tournament }) {
-  return <div>Test: {tournament?.tournament_name}</div>;
+  return (
+    <div className="flex justify-between flex-1">
+      <div className="flex flex-col">
+        <div className="flex gap-4">
+          <h2 className="scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight first:mt-0">
+            {tournament.tournament_name}
+          </h2>
+          <Badge variant="outline" className="flex gap-2 max-h-min">
+            <CircleUserRound />
+            {tournament.is_public ? "Public" : "Private"}
+          </Badge>
+        </div>
+        <p className="leading-7 [&:not(:first-child)]:mt-6">
+          {tournament.description}
+        </p>
+      </div>
+      <Button variant="secondary">
+        <Pencil />
+        Edit
+      </Button>
+    </div>
+  );
 }
 
 export default TournamentHeader;

--- a/tournament_app/app/tournaments/[tournament]/TournamentHeader.tsx
+++ b/tournament_app/app/tournaments/[tournament]/TournamentHeader.tsx
@@ -1,0 +1,8 @@
+import { Tournament } from "@/components/lib/types";
+import React from "react";
+
+function TournamentHeader({ tournament }: { tournament: Tournament }) {
+  return <div>Test: {tournament?.tournament_name}</div>;
+}
+
+export default TournamentHeader;

--- a/tournament_app/app/tournaments/[tournament]/drafts/page.tsx
+++ b/tournament_app/app/tournaments/[tournament]/drafts/page.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+function Page() {
+  return <div>Drafts</div>;
+}
+
+export default Page;

--- a/tournament_app/app/tournaments/[tournament]/layout.tsx
+++ b/tournament_app/app/tournaments/[tournament]/layout.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import React, { use } from "react";
+import TournamentHeader from "./TournamentHeader";
+import { useFetchTournamentById } from "@/components/api/hooks/useTournaments";
+
+function TournamentLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ tournament: string }>;
+}) {
+  const t = use(params);
+  const tournamentId = t.tournament;
+  const { data, error, isLoading } = useFetchTournamentById(tournamentId);
+
+  if (isLoading) return <div>Loading... </div>;
+
+  return (
+    <>
+      <TournamentHeader tournament={data} />
+      {children}
+    </>
+  );
+}
+
+export default TournamentLayout;

--- a/tournament_app/app/tournaments/[tournament]/layout.tsx
+++ b/tournament_app/app/tournaments/[tournament]/layout.tsx
@@ -18,10 +18,10 @@ function TournamentLayout({
   if (isLoading) return <div>Loading... </div>;
 
   return (
-    <>
+    <div className="m-10">
       <TournamentHeader tournament={data} />
       {children}
-    </>
+    </div>
   );
 }
 

--- a/tournament_app/app/tournaments/[tournament]/layout.tsx
+++ b/tournament_app/app/tournaments/[tournament]/layout.tsx
@@ -3,6 +3,7 @@
 import React, { use } from "react";
 import TournamentHeader from "./TournamentHeader";
 import { useFetchTournamentById } from "@/components/api/hooks/useTournaments";
+import NavBar from "./NavBar";
 
 function TournamentLayout({
   children,
@@ -18,8 +19,11 @@ function TournamentLayout({
   if (isLoading) return <div>Loading... </div>;
 
   return (
-    <div className="m-10">
+    <div className="m-10 flex flex-col gap-4">
       <TournamentHeader tournament={data} />
+      <div className="flex items-center justify-center">
+        <NavBar tournamentId={tournamentId} />
+      </div>
       {children}
     </div>
   );

--- a/tournament_app/app/tournaments/[tournament]/page.tsx
+++ b/tournament_app/app/tournaments/[tournament]/page.tsx
@@ -4,12 +4,8 @@ import { useFetchTournamentById } from "@/components/api/hooks/useTournaments";
 import React from "react";
 import { use } from "react";
 
-function Page({ params }: { params: Promise<{ tournament: string }> }) {
-  const t = use(params);
-  const tournamentId = t.tournament;
-
-  const { data, error, isLoading } = useFetchTournamentById(tournamentId);
-  return <div>Test: {data?.tournament_name}</div>;
+function Page() {
+  return <></>;
 }
 
 export default Page;

--- a/tournament_app/app/tournaments/[tournament]/page.tsx
+++ b/tournament_app/app/tournaments/[tournament]/page.tsx
@@ -1,8 +1,15 @@
-import React from "react";
+"use client";
 
-async function Page({ params }: { params: Promise<{ tournament: string }> }) {
-  const tournamentID = (await params).tournament;
-  return <div>Test: {tournamentID}</div>;
+import { useFetchTournamentById } from "@/components/api/hooks/useTournaments";
+import React from "react";
+import { use } from "react";
+
+function Page({ params }: { params: Promise<{ tournament: string }> }) {
+  const t = use(params);
+  const tournamentId = t.tournament;
+
+  const { data, error, isLoading } = useFetchTournamentById(tournamentId);
+  return <div>Test: {data?.tournament_name}</div>;
 }
 
 export default Page;

--- a/tournament_app/app/tournaments/[tournament]/people/PersonCard.tsx
+++ b/tournament_app/app/tournaments/[tournament]/people/PersonCard.tsx
@@ -1,7 +1,25 @@
 import React from "react";
 
-function PersonCard() {
-  return <div></div>;
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+
+function PersonCard(props: {
+  imageSrc: string;
+  fallbackText: string;
+  personName: string;
+}) {
+  return (
+    <Card className="mb-2">
+      <CardContent className="flex items-center gap-2 p-6 shadow-sm hover:shadow-lg transition-shadow ease-in-out">
+        <Avatar>
+          <AvatarImage src={props.imageSrc} />
+          <AvatarFallback>{props.fallbackText}</AvatarFallback>
+        </Avatar>
+
+        <p>{props.personName}</p>
+      </CardContent>
+    </Card>
+  );
 }
 
 export default PersonCard;

--- a/tournament_app/app/tournaments/[tournament]/people/PersonCard.tsx
+++ b/tournament_app/app/tournaments/[tournament]/people/PersonCard.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+function PersonCard() {
+  return <div></div>;
+}
+
+export default PersonCard;

--- a/tournament_app/app/tournaments/[tournament]/people/Players.tsx
+++ b/tournament_app/app/tournaments/[tournament]/people/Players.tsx
@@ -4,8 +4,63 @@ import { UserPlus } from "lucide-react";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import PersonCard from "./PersonCard";
+import { ScrollArea } from "@/components/ui/scroll-area";
 
 function Players() {
+  const playerData = [
+    {
+      imageSrc: "https://randomuser.me/api/portraits/men/11.jpg",
+      fallbackText: "TS",
+      personName: "Tommy Sullivan",
+    },
+    {
+      imageSrc: "https://randomuser.me/api/portraits/men/12.jpg",
+      fallbackText: "AN",
+      personName: "Adam Norris",
+    },
+    {
+      imageSrc: "https://randomuser.me/api/portraits/men/13.jpg",
+      fallbackText: "JM",
+      personName: "Jake Miller",
+    },
+    {
+      imageSrc: "https://randomuser.me/api/portraits/men/14.jpg",
+      fallbackText: "EB",
+      personName: "Ethan Brown",
+    },
+    {
+      imageSrc: "https://randomuser.me/api/portraits/men/15.jpg",
+      fallbackText: "RW",
+      personName: "Ryan Williams",
+    },
+    {
+      imageSrc: "https://randomuser.me/api/portraits/men/16.jpg",
+      fallbackText: "MC",
+      personName: "Max Cooper",
+    },
+    {
+      imageSrc: "https://randomuser.me/api/portraits/men/17.jpg",
+      fallbackText: "LB",
+      personName: "Liam Brooks",
+    },
+    {
+      imageSrc: "https://randomuser.me/api/portraits/men/18.jpg",
+      fallbackText: "FS",
+      personName: "Frank Smith",
+    },
+    {
+      imageSrc: "https://randomuser.me/api/portraits/men/19.jpg",
+      fallbackText: "PS",
+      personName: "Paul Simmons",
+    },
+    {
+      imageSrc: "https://randomuser.me/api/portraits/men/20.jpg",
+      fallbackText: "DW",
+      personName: "Derek Wallace",
+    },
+  ];
+
   return (
     <Card className="flex flex-col w-2/3 min-w-[400px]">
       <CardHeader className="flex flex-row justify-between items-center space-y-0">
@@ -15,7 +70,18 @@ function Players() {
         </Button>
       </CardHeader>
       <CardContent>
-        <p>Card Content</p>
+        <ScrollArea
+          className={"[&>[data-radix-scroll-area-viewport]]:max-h-[350px]"}
+        >
+          {playerData.map((player, index) => (
+            <PersonCard
+              key={index}
+              imageSrc={player.imageSrc}
+              fallbackText={player.fallbackText}
+              personName={player.personName}
+            />
+          ))}
+        </ScrollArea>
       </CardContent>
     </Card>
   );

--- a/tournament_app/app/tournaments/[tournament]/people/Players.tsx
+++ b/tournament_app/app/tournaments/[tournament]/people/Players.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+import { UserPlus } from "lucide-react";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+function Players() {
+  return (
+    <Card className="flex flex-col w-2/3 min-w-[400px]">
+      <CardHeader className="flex flex-row justify-between items-center space-y-0">
+        <CardTitle>Players</CardTitle>
+        <Button variant="outline">
+          <UserPlus /> Add
+        </Button>
+      </CardHeader>
+      <CardContent>
+        <p>Card Content</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default Players;

--- a/tournament_app/app/tournaments/[tournament]/people/Referees.tsx
+++ b/tournament_app/app/tournaments/[tournament]/people/Referees.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+import { UserPlus } from "lucide-react";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+function Referees() {
+  return (
+    <Card className="flex flex-col w-1/3 min-w-[250px]">
+      <CardHeader className="flex flex-row justify-between items-center space-y-0">
+        <CardTitle>Referees</CardTitle>
+        <Button variant="outline">
+          <UserPlus /> Add
+        </Button>
+      </CardHeader>
+      <CardContent>
+        <p>Card Content</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default Referees;

--- a/tournament_app/app/tournaments/[tournament]/people/Referees.tsx
+++ b/tournament_app/app/tournaments/[tournament]/people/Referees.tsx
@@ -4,8 +4,63 @@ import { UserPlus } from "lucide-react";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import PersonCard from "./PersonCard";
+import { ScrollArea } from "@/components/ui/scroll-area";
 
 function Referees() {
+  const refereeData = [
+    {
+      imageSrc: "https://randomuser.me/api/portraits/men/1.jpg",
+      fallbackText: "JS",
+      personName: "John Smith",
+    },
+    {
+      imageSrc: "https://randomuser.me/api/portraits/men/2.jpg",
+      fallbackText: "MP",
+      personName: "Mark Peterson",
+    },
+    {
+      imageSrc: "https://randomuser.me/api/portraits/men/3.jpg",
+      fallbackText: "RM",
+      personName: "Richard Moore",
+    },
+    {
+      imageSrc: "https://randomuser.me/api/portraits/men/4.jpg",
+      fallbackText: "DW",
+      personName: "David Williams",
+    },
+    {
+      imageSrc: "https://randomuser.me/api/portraits/men/5.jpg",
+      fallbackText: "TP",
+      personName: "Thomas Parker",
+    },
+    {
+      imageSrc: "https://randomuser.me/api/portraits/men/6.jpg",
+      fallbackText: "BJ",
+      personName: "Brian Johnson",
+    },
+    {
+      imageSrc: "https://randomuser.me/api/portraits/men/7.jpg",
+      fallbackText: "JS",
+      personName: "James Stevens",
+    },
+    {
+      imageSrc: "https://randomuser.me/api/portraits/men/8.jpg",
+      fallbackText: "AW",
+      personName: "Alan White",
+    },
+    {
+      imageSrc: "https://randomuser.me/api/portraits/men/9.jpg",
+      fallbackText: "CK",
+      personName: "Charles King",
+    },
+    {
+      imageSrc: "https://randomuser.me/api/portraits/men/10.jpg",
+      fallbackText: "MC",
+      personName: "Matthew Clark",
+    },
+  ];
+
   return (
     <Card className="flex flex-col w-1/3 min-w-[250px]">
       <CardHeader className="flex flex-row justify-between items-center space-y-0">
@@ -15,7 +70,18 @@ function Referees() {
         </Button>
       </CardHeader>
       <CardContent>
-        <p>Card Content</p>
+        <ScrollArea
+          className={"[&>[data-radix-scroll-area-viewport]]:max-h-[350px]"}
+        >
+          {refereeData.map((referee, index) => (
+            <PersonCard
+              key={index}
+              imageSrc={referee.imageSrc}
+              fallbackText={referee.fallbackText}
+              personName={referee.personName}
+            />
+          ))}
+        </ScrollArea>
       </CardContent>
     </Card>
   );

--- a/tournament_app/app/tournaments/[tournament]/people/page.tsx
+++ b/tournament_app/app/tournaments/[tournament]/people/page.tsx
@@ -1,7 +1,14 @@
 import React from "react";
+import Players from "./Players";
+import Referees from "./Referees";
 
 function Page() {
-  return <div>People</div>;
+  return (
+    <div className="flex gap-6 items-start">
+      <Referees />
+      <Players />
+    </div>
+  );
 }
 
 export default Page;

--- a/tournament_app/app/tournaments/[tournament]/people/page.tsx
+++ b/tournament_app/app/tournaments/[tournament]/people/page.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+function Page() {
+  return <div>People</div>;
+}
+
+export default Page;

--- a/tournament_app/app/tournaments/[tournament]/rules/page.tsx
+++ b/tournament_app/app/tournaments/[tournament]/rules/page.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+function Page() {
+  return <div>Rules</div>;
+}
+
+export default Page;

--- a/tournament_app/app/tournaments/[tournament]/schedule/page.tsx
+++ b/tournament_app/app/tournaments/[tournament]/schedule/page.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+function Page() {
+  return <div>Schedule</div>;
+}
+
+export default Page;

--- a/tournament_app/app/tournaments/page.tsx
+++ b/tournament_app/app/tournaments/page.tsx
@@ -18,12 +18,9 @@ export default function Page(props: PageProps) {
   return (
     <div className=" m-10">
       <div className="flex flex-row justify-between">
-        <Label
-          className={`font-semibold mb-[18px]`}
-          style={{ fontSize: "32px" }}
-        >
+        <h1 className="scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl mb-4">
           Tournaments
-        </Label>
+        </h1>
         <Button className="max-w-[90px]" type="button">
           <Link href="/tournaments/create">Create</Link>
         </Button>

--- a/tournament_app/components.json
+++ b/tournament_app/components.json
@@ -12,6 +12,9 @@
   },
   "aliases": {
     "components": "@/components",
-    "utils": "@/lib/utils"
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
   }
 }

--- a/tournament_app/components/ui/avatar.tsx
+++ b/tournament_app/components/ui/avatar.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import * as React from "react";
+import * as AvatarPrimitive from "@radix-ui/react-avatar";
+
+import { cn } from "@/components/lib/utils";
+
+const Avatar = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
+      className
+    )}
+    {...props}
+  />
+));
+Avatar.displayName = AvatarPrimitive.Root.displayName;
+
+const AvatarImage = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Image>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Image
+    ref={ref}
+    className={cn("aspect-square h-full w-full", className)}
+    {...props}
+  />
+));
+AvatarImage.displayName = AvatarPrimitive.Image.displayName;
+
+const AvatarFallback = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Fallback>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Fallback
+    ref={ref}
+    className={cn(
+      "flex h-full w-full items-center justify-center rounded-full bg-muted",
+      className
+    )}
+    {...props}
+  />
+));
+AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName;
+
+export { Avatar, AvatarImage, AvatarFallback };

--- a/tournament_app/components/ui/badge.tsx
+++ b/tournament_app/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/components/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/tournament_app/components/ui/navigation-menu.tsx
+++ b/tournament_app/components/ui/navigation-menu.tsx
@@ -1,0 +1,128 @@
+import * as React from "react";
+import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu";
+import { cva } from "class-variance-authority";
+import { ChevronDown } from "lucide-react";
+
+import { cn } from "@/components/lib/utils";
+
+const NavigationMenu = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Root>
+>(({ className, children, ...props }, ref) => (
+  <NavigationMenuPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative z-10 flex max-w-max flex-1 items-center justify-center",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <NavigationMenuViewport />
+  </NavigationMenuPrimitive.Root>
+));
+NavigationMenu.displayName = NavigationMenuPrimitive.Root.displayName;
+
+const NavigationMenuList = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <NavigationMenuPrimitive.List
+    ref={ref}
+    className={cn(
+      "group flex flex-1 list-none items-center justify-center space-x-1",
+      className
+    )}
+    {...props}
+  />
+));
+NavigationMenuList.displayName = NavigationMenuPrimitive.List.displayName;
+
+const NavigationMenuItem = NavigationMenuPrimitive.Item;
+
+const navigationMenuTriggerStyle = cva(
+  "group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active]:bg-accent/50 data-[state=open]:bg-accent/50"
+);
+
+const NavigationMenuTrigger = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <NavigationMenuPrimitive.Trigger
+    ref={ref}
+    className={cn(navigationMenuTriggerStyle(), "group", className)}
+    {...props}
+  >
+    {children}{" "}
+    <ChevronDown
+      className="relative top-[1px] ml-1 h-3 w-3 transition duration-200 group-data-[state=open]:rotate-180"
+      aria-hidden="true"
+    />
+  </NavigationMenuPrimitive.Trigger>
+));
+NavigationMenuTrigger.displayName = NavigationMenuPrimitive.Trigger.displayName;
+
+const NavigationMenuContent = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <NavigationMenuPrimitive.Content
+    ref={ref}
+    className={cn(
+      "left-0 top-0 w-full data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 md:absolute md:w-auto ",
+      className
+    )}
+    {...props}
+  />
+));
+NavigationMenuContent.displayName = NavigationMenuPrimitive.Content.displayName;
+
+const NavigationMenuLink = NavigationMenuPrimitive.Link;
+
+const NavigationMenuViewport = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitive.Viewport>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Viewport>
+>(({ className, ...props }, ref) => (
+  <div className={cn("absolute left-0 top-full flex justify-center")}>
+    <NavigationMenuPrimitive.Viewport
+      className={cn(
+        "origin-top-center relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 md:w-[var(--radix-navigation-menu-viewport-width)]",
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  </div>
+));
+NavigationMenuViewport.displayName =
+  NavigationMenuPrimitive.Viewport.displayName;
+
+const NavigationMenuIndicator = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitive.Indicator>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Indicator>
+>(({ className, ...props }, ref) => (
+  <NavigationMenuPrimitive.Indicator
+    ref={ref}
+    className={cn(
+      "top-full z-[1] flex h-1.5 items-end justify-center overflow-hidden data-[state=visible]:animate-in data-[state=hidden]:animate-out data-[state=hidden]:fade-out data-[state=visible]:fade-in",
+      className
+    )}
+    {...props}
+  >
+    <div className="relative top-[60%] h-2 w-2 rotate-45 rounded-tl-sm bg-border shadow-md" />
+  </NavigationMenuPrimitive.Indicator>
+));
+NavigationMenuIndicator.displayName =
+  NavigationMenuPrimitive.Indicator.displayName;
+
+export {
+  navigationMenuTriggerStyle,
+  NavigationMenu,
+  NavigationMenuList,
+  NavigationMenuItem,
+  NavigationMenuContent,
+  NavigationMenuTrigger,
+  NavigationMenuLink,
+  NavigationMenuIndicator,
+  NavigationMenuViewport,
+};

--- a/tournament_app/components/ui/scroll-area.tsx
+++ b/tournament_app/components/ui/scroll-area.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import * as React from "react";
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area";
+
+import { cn } from "@/components/lib/utils";
+
+const ScrollArea = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
+>(({ className, children, ...props }, ref) => (
+  <ScrollAreaPrimitive.Root
+    ref={ref}
+    className={cn("relative overflow-hidden", className)}
+    {...props}
+  >
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+      {children}
+    </ScrollAreaPrimitive.Viewport>
+    <ScrollBar />
+    <ScrollAreaPrimitive.Corner />
+  </ScrollAreaPrimitive.Root>
+));
+ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName;
+
+const ScrollBar = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
+>(({ className, orientation = "vertical", ...props }, ref) => (
+  <ScrollAreaPrimitive.ScrollAreaScrollbar
+    ref={ref}
+    orientation={orientation}
+    className={cn(
+      "flex touch-none select-none transition-colors",
+      orientation === "vertical" &&
+        "h-full w-2.5 border-l border-l-transparent p-[1px]",
+      orientation === "horizontal" &&
+        "h-2.5 flex-col border-t border-t-transparent p-[1px]",
+      className
+    )}
+    {...props}
+  >
+    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
+  </ScrollAreaPrimitive.ScrollAreaScrollbar>
+));
+ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName;
+
+export { ScrollArea, ScrollBar };

--- a/tournament_app/package-lock.json
+++ b/tournament_app/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-dialog": "^1.1.4",
         "@radix-ui/react-icons": "^1.3.2",
         "@radix-ui/react-label": "^2.1.1",
+        "@radix-ui/react-navigation-menu": "^1.2.5",
         "@radix-ui/react-select": "^2.1.4",
         "@radix-ui/react-separator": "^1.1.1",
         "@radix-ui/react-slot": "^1.1.1",
@@ -1830,6 +1831,153 @@
       "integrity": "sha512-UUw5E4e/2+4kFMH7+YxORXGWggtY6sM8WIwh5RZchhLuUg2H1hc98Py+pr8HMz6rdaYrK2t296ZEjYLOCO5uUw==",
       "dependencies": {
         "@radix-ui/react-primitive": "2.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-navigation-menu": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.5.tgz",
+      "integrity": "sha512-myMHHQUZ3ZLTi8W381/Vu43Ia0NqakkQZ2vzynMmTUtQQ9kNkjzhOwkZC9TAM5R07OZUVIQyHC06f/9JZJpvvA==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-collection": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.5",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-use-previous": "1.1.0",
+        "@radix-ui/react-visually-hidden": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-navigation-menu/node_modules/@radix-ui/react-collection": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.2.tgz",
+      "integrity": "sha512-9z54IEKRxIa9VityapoEYMuByaG42iSy1ZXlY2KcuLSEtq8x4987/N6m15ppoMffgZX72gER2uHe1D9Y6Unlcw==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-slot": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-navigation-menu/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.5.tgz",
+      "integrity": "sha512-E4TywXY6UsXNRhFrECa5HAvE5/4BFcGyfTyK36gP+pAW1ed7UTK4vKwdr53gAJYwqbfCWC6ATvJa3J3R/9+Qrg==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-escape-keydown": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-navigation-menu/node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.2.tgz",
+      "integrity": "sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-navigation-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.2.tgz",
+      "integrity": "sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-navigation-menu/node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.1.2.tgz",
+      "integrity": "sha512-1SzA4ns2M1aRlvxErqhLHsBHoS5eI5UUcI2awAMgGUp4LoaoWOKYmvqDY2s/tltuPkh3Yk77YF/r3IRj+Amx4Q==",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.2"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/tournament_app/package-lock.json
+++ b/tournament_app/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
+        "@radix-ui/react-avatar": "^1.1.3",
         "@radix-ui/react-dialog": "^1.1.4",
         "@radix-ui/react-icons": "^1.3.2",
         "@radix-ui/react-label": "^2.1.1",
         "@radix-ui/react-navigation-menu": "^1.2.5",
+        "@radix-ui/react-scroll-area": "^1.2.3",
         "@radix-ui/react-select": "^2.1.4",
         "@radix-ui/react-separator": "^1.1.1",
         "@radix-ui/react-slot": "^1.1.1",
@@ -1634,6 +1636,70 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-avatar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.3.tgz",
+      "integrity": "sha512-Paen00T4P8L8gd9bNsRMw7Cbaz85oxiv+hzomsRZgFm2byltPFDtfcoqlWJ8GyZlIBWgLssJlzLCnKU0G0302g==",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar/node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.2.tgz",
+      "integrity": "sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar/node_modules/@radix-ui/react-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.2.tgz",
+      "integrity": "sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-collection": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.1.tgz",
@@ -2089,6 +2155,75 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.3.tgz",
+      "integrity": "sha512-l7+NNBfBYYJa9tNqVcP2AGvxdE3lmE6kFTBXdvHgUaZuy+4wGCL1Cl2AfaR7RKyimj7lZURGLwFO59k4eBnDJQ==",
+      "dependencies": {
+        "@radix-ui/number": "1.1.0",
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.2.tgz",
+      "integrity": "sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.2.tgz",
+      "integrity": "sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }

--- a/tournament_app/package.json
+++ b/tournament_app/package.json
@@ -10,10 +10,12 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
+    "@radix-ui/react-avatar": "^1.1.3",
     "@radix-ui/react-dialog": "^1.1.4",
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/react-label": "^2.1.1",
     "@radix-ui/react-navigation-menu": "^1.2.5",
+    "@radix-ui/react-scroll-area": "^1.2.3",
     "@radix-ui/react-select": "^2.1.4",
     "@radix-ui/react-separator": "^1.1.1",
     "@radix-ui/react-slot": "^1.1.1",

--- a/tournament_app/package.json
+++ b/tournament_app/package.json
@@ -13,6 +13,7 @@
     "@radix-ui/react-dialog": "^1.1.4",
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/react-label": "^2.1.1",
+    "@radix-ui/react-navigation-menu": "^1.2.5",
     "@radix-ui/react-select": "^2.1.4",
     "@radix-ui/react-separator": "^1.1.1",
     "@radix-ui/react-slot": "^1.1.1",


### PR DESCRIPTION
### **Changes**

- Add the following shadcn/ui components:
  - Badge
  - Navigation Menu
  - Avatar
  - Scroll-area
- Implement nested layout within the tournament page
- Create mock layout for "People" section within tournament page

### **TODO**

- Implement remaining sections:
  - Rules
  - Drafts (brackets display)
  - Schedules
- Update backend to handle user logic, RBAC

### **Sample Tournament Page**
![image](https://github.com/user-attachments/assets/6909b5a8-0970-4b8a-865b-4c330862bced)
